### PR TITLE
fix: max and min functions

### DIFF
--- a/common/changes/@ts-utils/array/fix-max-min_2019-10-17-07-25.json
+++ b/common/changes/@ts-utils/array/fix-max-min_2019-10-17-07-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@ts-utils/array",
+      "comment": "Fix the max and min functions.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@ts-utils/array",
+  "email": "tnc1997@virginmedia.com"
+}

--- a/libraries/array/src/max.ts
+++ b/libraries/array/src/max.ts
@@ -5,5 +5,5 @@
  * @public
  */
 export function max(array: number[]): number {
-  return array.sort()[array.length - 1];
+  return array.sort((a, b) => b - a)[0];
 }

--- a/libraries/array/src/min.ts
+++ b/libraries/array/src/min.ts
@@ -5,5 +5,5 @@
  * @public
  */
 export function min(array: number[]): number {
-  return array.sort()[0];
+  return array.sort((a, b) => a - b)[0];
 }

--- a/libraries/array/test/max.spec.ts
+++ b/libraries/array/test/max.spec.ts
@@ -2,6 +2,6 @@ import {max} from '../src/max';
 
 describe('max', () => {
   it('should return the maximum value of an array', () => {
-    expect(max([1, 2, 3, 4, 5])).toEqual(5);
+    expect(max([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toEqual(10);
   });
 });

--- a/libraries/array/test/min.spec.ts
+++ b/libraries/array/test/min.spec.ts
@@ -2,6 +2,6 @@ import {min} from '../src/min';
 
 describe('min', () => {
   it('should return the minimum value of an array', () => {
-    expect(min([1, 2, 3, 4, 5])).toEqual(1);
+    expect(min([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toEqual(1);
   });
 });


### PR DESCRIPTION
## Pull Request Checklist
<!-- Check if your pull request fulfills the requirements. -->
- [x] Commit Message Follows Guidelines
- [x] Tests For Changes Have Been Added
- [ ] Docs Have Been Added Or Updated

## Current Behaviour
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The max and min functions currently use the default sort method which compares values as strings.

## New Behaviour
<!-- Please describe the new behavior that you have implemented. -->
The max and min functions now use a comparer function which compares values as numbers.